### PR TITLE
Add in ability to add mark single field as duplicate

### DIFF
--- a/pitchfork/forms.py
+++ b/pitchfork/forms.py
@@ -101,6 +101,7 @@ class CallVariables(Form):
     field_display_data = fields.TextAreaField('Select Data:')
     description = fields.TextField('Short Description:')
     required = fields.BooleanField('Required:')
+    duplicate = fields.BooleanField('Allow Duplicate:', default=False)
     id_value = fields.HiddenField('id_value', default=0)
 
 

--- a/pitchfork/helper.py
+++ b/pitchfork/helper.py
@@ -345,6 +345,12 @@ def recursive_dict_object(
 
                 if len(temp_list_dict) > 0:
                     temp_list.append(copy.deepcopy(temp_list_dict))
+                    temp_list = [
+                        dict(temp_set) for temp_set in set(
+                            tuple(item.items())
+                            for item in temp_list
+                        )
+                    ]
 
             else:
                 _key = re.match('\{(.+?)\}', value_list)

--- a/pitchfork/models.py
+++ b/pitchfork/models.py
@@ -208,6 +208,7 @@ class Variable:
         self.field_type = variable.get('field_type')
         self.description = variable.get('description')
         self.required = bool(variable.get('required'))
+        self.duplicate = bool(variable.get('duplicate'))
         self.field_display_data = variable.get('field_display_data')
         self.id_value = int(variable.get('id_value', 0))
         self.field_display = variable.get('field_display')

--- a/pitchfork/templates/_call_layout.html
+++ b/pitchfork/templates/_call_layout.html
@@ -78,6 +78,7 @@
                         {% if api_call.get('variables') or api_call.get('allow_filter') %}
                             <table class="table">
                                 <tr>
+                                    <th></th>
                                     <th>Parameter</th>
                                     <th></th>
                                     <th>Type</th>
@@ -86,6 +87,11 @@
                                 </tr>
                                 {% for var in api_call.get('variables') %}
                                     <tr>
+                                        <td width="26px">
+                                            {% if var.get('duplicate') %}
+                                                <a class="duplicate-field tooltip-title" title="Add Network"><span class="fa fa-plus text-success"></span></a>
+                                            {% endif -%}
+                                        </td>
                                         <td>
                                             {{ var.get('variable_name') }}
                                         </td>

--- a/pitchfork/templates/manage/manage_api_calls.html
+++ b/pitchfork/templates/manage/manage_api_calls.html
@@ -41,7 +41,7 @@
                     <td>
                         {% if api.get('variables') %}
                             {% for var in api.get('variables') %}
-                                <span {% if var.get('required') %}class="text-danger"><span class="fa fa-start tooltip-title" title="Required Attribute"></span{% endif %}>{{ var.get('variable_name') }}</span><br />
+                                <span {% if var.get('required') %}class="text-danger">{% else %}>{% endif %}{{ var.get('variable_name') }}</span>{% if var.get('duplicate') %}<span class="text-success tooltip_show" title="Allow duplicate values">&nbsp; &nbsp;<strong>D</strong></span>{% endif -%}<br />
                             {% endfor %}
                         {% endif %}
                     </td>

--- a/pitchfork/templates/product_front.html
+++ b/pitchfork/templates/product_front.html
@@ -137,5 +137,37 @@
         $('body').on('hidden.bs.modal', '.modal', function () {
             $(this).find('form')[0].reset();
         });
+
+        $('.duplicate-field').on('click', function() {
+            $(this).tooltip('destroy');
+            var parent_row = $(this).parent().parent();
+            var orig_input = parent_row.find('input');
+            var clone_row = $(this).parent().parent().clone(true);
+            var current_name = parent_row.find('input').attr('name');
+            var items = current_name.split('_');
+            var count = parseInt(items[items.length -1]);
+            if (count < 2 || isNaN(count)) {
+                if (parseInt(items[items.length -1])) {
+                    items.pop();
+                    clone_row.find('input').attr('name', items.join('_') + '_' + (count + 1));
+                    clone_row.find('input').attr('id', items.join('_') + '_' + (count + 1));
+                } else {
+                    clone_row.find('input').attr('name', items.join('_') + '_1');
+                    clone_row.find('input').attr('id', items.join('_') + '_1');
+                }
+                clone_row.find('input').val('');
+                $(this).hide();
+
+                var duplicate = clone_row.find('.duplicate-field');
+                if ((count + 1) === 2) {
+                    duplicate.hide();
+                } else {
+                    duplicate.attr('title', 'Add Network');
+                    duplicate.removeAttr('data-original-title');
+                }
+                parent_row.after(clone_row);
+                $('.tooltip-title').tooltip();
+            }
+        });
 	</script>
 {% endblock %}

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -96,6 +96,7 @@ class ProductTests(unittest.TestCase):
                     'field_type': 'text',
                     'description': 'Test Variable',
                     'required': True,
+                    'duplicate': True,
                     'field_display_data': '',
                     'id_value': 0,
                     'field_display': 'TextField',
@@ -878,6 +879,7 @@ class ProductTests(unittest.TestCase):
         )
 
     def test_pf_autoscale_api_user_perms(self):
+        self.setup_useable_api_call_with_variables()
         with self.app as c:
             with c.session_transaction() as sess:
                 self.setup_user_login(sess)
@@ -891,6 +893,11 @@ class ProductTests(unittest.TestCase):
             'Autoscale',
             response.data,
             'Did not find correct HTML on page'
+        )
+        self.assertIn(
+            'duplicate-field',
+            response.data.decode('utf-8'),
+            'Could not find expected class on page'
         )
 
     def test_pf_autoscale_api_admin_perms_no_settings(self):

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -567,6 +567,61 @@ class ProductTests(unittest.TestCase):
         found_call = self.db.autoscale.find()
         assert found_call.count() == 0, 'No calls should have been found'
 
+
+    def test_pf_autoscale_manage_api_add_post_with_vars(self):
+        self.db.autoscale.remove()
+        with self.app as c:
+            with c.session_transaction() as sess:
+                self.setup_admin_login(sess)
+
+            response = c.get(
+                '/autoscale/manage/api/add'
+            )
+            token = self.retrieve_csrf_token(response.data)
+            data = {
+                'csrf_token': token,
+                'title': 'Add Call',
+                'doc_url': 'http://docs.rackspace.com',
+                'verb': 'GET',
+                'api_uri': '/v1.0/{ddi}/groups',
+                'group': 'add_new_group',
+                'new_group': 'Test Group',
+                'product': 'autoscale',
+                'variable_0-description': 'Test variable',
+                'variable_0-duplicate': 'y',
+                'variable_0-field_display': 'TextField',
+                'variable_0-field_type': 'text',
+                'variable_0-variable_name': 'test_var',
+                'variable_0-field_display_data': '',
+                'variable_0-required': 'y'
+            }
+            response = c.post(
+                '/autoscale/manage/api/add',
+                data=data,
+                follow_redirects=True
+            )
+
+        self.assertIn(
+            'API Call was added successfully',
+            response.data,
+            'Bad message when submitting good call'
+        )
+        calls = self.db.autoscale.find()
+        found = self.db.autoscale.find_one()
+        assert calls.count() == 1, 'Incorrect count of calls'
+        assert found.get('group') == 'test_group', (
+            'Group not find or incorrect group'
+        )
+        group = self.db.api_settings.find_one(
+            {'autoscale.groups.slug': 'test_group'}
+        )
+        assert group, 'Could not find added group'
+
+        assert len(found.get('variables')) == 1, 'Incorrect variable length'
+        variable = found.get('variables')[0]
+        assert variable.get('required'), 'Variable should be required'
+        assert variable.get('duplicate'), 'Variable should be a duplicate'
+
     """ Edit API Call """
 
     def test_pf_autoscale_manage_api_edit_user_perms(self):

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -567,7 +567,6 @@ class ProductTests(unittest.TestCase):
         found_call = self.db.autoscale.find()
         assert found_call.count() == 0, 'No calls should have been found'
 
-
     def test_pf_autoscale_manage_api_add_post_with_vars(self):
         self.db.autoscale.remove()
         with self.app as c:


### PR DESCRIPTION
This allows for requests to be created specifically for adding multiple networks. The fix affects the following calls:

Autoscale - Create Group config
Autoscale - Replace Launch Config
Autoscale - Replace Launch Config (BFV)
Servers - Create Server
Servers - Create Server (BFV)